### PR TITLE
Fix tab navigation in theme settings accessibility test

### DIFF
--- a/e2e-tests/playwright/specs/accessibility/channels/theme_settings.spec.ts
+++ b/e2e-tests/playwright/specs/accessibility/channels/theme_settings.spec.ts
@@ -33,7 +33,6 @@ test('Theme settings should be keyboard accessible', async ({axe, pw}) => {
     await settingsModal.container.focus();
     await page.keyboard.press('Tab');
     await page.keyboard.press('Tab');
-    await page.keyboard.press('Tab');
     await page.keyboard.press('ArrowDown');
 
     // * The display tab should be open


### PR DESCRIPTION
Removed an extra Tab keypress that was causing `theme_settings.spec.ts` to fail while verifying tab navigation in Settings > Display > Theme. Looks like recent changes to the Settings modal changed the number of tabs needed to reach the target.
